### PR TITLE
Add finances section with cards button to settings modal

### DIFF
--- a/main.js
+++ b/main.js
@@ -386,6 +386,14 @@ function renderSettingsModal(){
       </div>
     </div>
 
+    <h2 class="settings-title" style="margin:18px 0 8px 0;font-size:1rem;font-weight:700;color:var(--txt-main);">Finanças</h2>
+    <div class="settings-list">
+      <button type="button" class="settings-item settings-link" id="settingsCardsBtn">
+        <span class="left">Cartões</span>
+        <span class="right"></span>
+      </button>
+    </div>
+
     <h2 class="settings-title" style="margin:18px 0 8px 0;font-size:1rem;font-weight:700;color:var(--txt-main);">Sobre</h2>
     <div class="settings-list">
       <div class="settings-item">

--- a/style.css
+++ b/style.css
@@ -2126,8 +2126,25 @@ html[data-theme="light"] .invoice .invoice-group-date{ color: #111; }
 .settings-name{font-weight:800;font-size:1.05rem;color:#fff;}
 .settings-sub{font-size:.9rem;color:#c9c9c9;opacity:.9;}
 .settings-list{background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.12);border-radius:18px;overflow:hidden;}
-.settings-item{display:flex;align-items:center;justify-content:space-between;padding:14px 14px;border-top:1px solid rgba(255,255,255,.06);} 
+.settings-item{display:flex;align-items:center;justify-content:space-between;padding:14px 14px;border-top:1px solid rgba(255,255,255,.06);}
 .settings-item:first-child{border-top:none;}
+
+.settings-list .settings-item.settings-link{
+  background:none;
+  border:none;
+  width:100%;
+  text-align:left;
+  color:inherit;
+  font:inherit;
+  cursor:pointer;
+}
+.settings-list .settings-item.settings-link:focus{
+  outline:none;
+}
+.settings-list .settings-item.settings-link:focus-visible{
+  box-shadow:inset 0 0 0 2px var(--focus-ring, #f59e0b);
+  border-radius:0; /* relies on container radius */
+}
 
 /* Theme selector card (iOS-like group) */
 .settings-theme-card{


### PR DESCRIPTION
## Summary
- add a Finanças section to the Ajustes modal layout
- include a Cartões button styled to match the existing version row visuals
- add styling to allow settings list buttons to adopt the list row presentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5bac5b7c88331b6eb8a662d6cba31