### PR TITLE
Open cards modal from settings with slide animation

### DIFF
--- a/main.js
+++ b/main.js
@@ -341,11 +341,7 @@ if (headerSeg) {
       headerSeg.dataset.selected = 'planned';
       openPlannedBtn.click();
     } else if (action === 'cards') {
-      const openCardBtn = document.getElementById('openCardModal');
-      if (openCardBtn) {
-        headerSeg.dataset.selected = 'cards';
-        openCardBtn.click();
-      }
+      headerSeg.dataset.selected = 'cards';
     }
   });
 }
@@ -384,6 +380,14 @@ function renderSettingsModal(){
           <div style="color:var(--txt-muted);font-size:18px;">›</div>
         </div>
       </div>
+    </div>
+
+    <h2 class="settings-title" style="margin:18px 0 8px 0;font-size:1rem;font-weight:700;color:var(--txt-main);">Finanças</h2>
+    <div class="settings-list">
+      <button type="button" class="settings-item settings-link" id="settingsCardsBtn">
+        <span class="left">Cartões</span>
+        <span class="right"></span>
+      </button>
     </div>
 
     <h2 class="settings-title" style="margin:18px 0 8px 0;font-size:1rem;font-weight:700;color:var(--txt-main);">Sobre</h2>
@@ -512,6 +516,14 @@ function renderSettingsModal(){
   if (closeCurrencyProfileModal && currencyProfileModalEl) {
     closeCurrencyProfileModal.addEventListener('click', () => { currencyProfileModalEl.classList.add('hidden'); updateModalOpenState(); });
     currencyProfileModalEl.addEventListener('click', (e) => { if (e.target === currencyProfileModalEl) { currencyProfileModalEl.classList.add('hidden'); updateModalOpenState(); } });
+  }
+
+  // Local "Cartões" shortcut inside settings
+  const settingsCardsBtn = box.querySelector('#settingsCardsBtn');
+  if (settingsCardsBtn) {
+    settingsCardsBtn.addEventListener('click', () => {
+      showCardModal({ fromSettings: true });
+    });
   }
 
   // Reset button inside settings modal
@@ -2791,6 +2803,49 @@ function openEditFlow(tx, iso) {
 const openCardBtn=document.getElementById('openCardModal');
 const cardModal=document.getElementById('cardModal');
 const closeCardModal=document.getElementById('closeCardModal');
+
+function showCardModal(options = {}) {
+  if (!cardModal) return;
+  const fromSettings = options.fromSettings === true;
+
+  if (fromSettings) {
+    cardModal.dataset.origin = 'settings';
+    cardModal.classList.add('from-settings');
+    cardModal.classList.remove('from-settings-visible');
+    cardModal.classList.remove('hidden');
+    void cardModal.offsetWidth;
+    cardModal.classList.add('from-settings-visible');
+  } else {
+    cardModal.dataset.origin = 'default';
+    cardModal.classList.remove('from-settings');
+    cardModal.classList.remove('from-settings-visible');
+    cardModal.classList.remove('hidden');
+  }
+
+  updateModalOpenState();
+
+  setTimeout(() => {
+    try { renderCardList(); }
+    catch (_) {}
+  }, 0);
+}
+
+function hideCardModal() {
+  if (!cardModal) return;
+  cardModal.classList.add('hidden');
+  cardModal.classList.remove('from-settings-visible');
+  if (!cardModal.dataset.origin || cardModal.dataset.origin !== 'settings') {
+    cardModal.classList.remove('from-settings');
+  } else {
+    setTimeout(() => {
+      if (cardModal.classList.contains('hidden')) {
+        cardModal.classList.remove('from-settings');
+      }
+    }, 320);
+  }
+  delete cardModal.dataset.origin;
+  updateModalOpenState();
+}
 
 function refreshMethods(){
   if (!met) return;
@@ -5130,9 +5185,15 @@ setStartBtn.addEventListener('click', async () => {
 });
 
 addCardBtn.onclick=addCard;addBtn.onclick=addTx;
-openCardBtn.onclick = () => { cardModal.classList.remove('hidden'); updateModalOpenState(); setTimeout(() => { try { renderCardList(); } catch(_) {} }, 0); };
-closeCardModal.onclick = () => { cardModal.classList.add('hidden'); updateModalOpenState(); };
-cardModal.onclick = e => { if (e.target === cardModal) { cardModal.classList.add('hidden'); updateModalOpenState(); } };
+if (openCardBtn) openCardBtn.onclick = () => showCardModal();
+if (closeCardModal) closeCardModal.onclick = hideCardModal;
+if (cardModal) {
+  cardModal.onclick = e => {
+    if (e.target === cardModal) {
+      hideCardModal();
+    }
+  };
+}
 
  (async () => {
     // Instancia todos os botões “Adicionar” a partir do template

--- a/style.css
+++ b/style.css
@@ -2126,8 +2126,25 @@ html[data-theme="light"] .invoice .invoice-group-date{ color: #111; }
 .settings-name{font-weight:800;font-size:1.05rem;color:#fff;}
 .settings-sub{font-size:.9rem;color:#c9c9c9;opacity:.9;}
 .settings-list{background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.12);border-radius:18px;overflow:hidden;}
-.settings-item{display:flex;align-items:center;justify-content:space-between;padding:14px 14px;border-top:1px solid rgba(255,255,255,.06);} 
+.settings-item{display:flex;align-items:center;justify-content:space-between;padding:14px 14px;border-top:1px solid rgba(255,255,255,.06);}
 .settings-item:first-child{border-top:none;}
+
+.settings-list .settings-item.settings-link{
+  background:none;
+  border:none;
+  width:100%;
+  text-align:left;
+  color:inherit;
+  font:inherit;
+  cursor:pointer;
+}
+.settings-list .settings-item.settings-link:focus{
+  outline:none;
+}
+.settings-list .settings-item.settings-link:focus-visible{
+  box-shadow:inset 0 0 0 2px var(--focus-ring, #f59e0b);
+  border-radius:0; /* relies on container radius */
+}
 
 /* Theme selector card (iOS-like group) */
 .settings-theme-card{
@@ -3096,6 +3113,17 @@ summary.day-summary:hover{box-shadow:0 8px 24px rgba(0,0,0,.55), 0 0 12px #00FF0
   border-radius: 12px;
   padding: 12px;
   color: #fff;
+}
+
+#cardModal.from-settings .bottom-modal-box {
+  transform: translateX(32px);
+  opacity: 0;
+  transition: transform .28s cubic-bezier(.22, 1, .36, 1), opacity .28s ease;
+}
+
+#cardModal.from-settings.from-settings-visible .bottom-modal-box {
+  transform: translateX(0);
+  opacity: 1;
 }
 .card-content {
   display: flex;


### PR DESCRIPTION
## Summary
- route the header cards tab selection without auto-opening the cards modal
- wire the Ajustes modal "Cartões" button to open the cards modal with nested slide-in behavior
- add slide-in styling for the cards modal when launched from Ajustes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5bac5b7c88331b6eb8a662d6cba31