### PR TITLE
Refine settings modal layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,15 +74,11 @@
   </div>
 
   <!-- Modal Sobre -->
-  <div id="settingsModal" class="bottom-modal backdrop-blur hidden">
+  <div id="settingsModal" class="bottom-modal backdrop-blur hidden" aria-labelledby="settingsSheetTitle">
     <div class="bottom-modal-box">
       <div class="modal-drag"></div>
-      <h2>Sobre</h2>
       <button id="closeSettingsModal" class="modal-close-btn" aria-label="Fechar">✕</button>
-      <div class="modal-content">
-  <button id="toggleThemeBtn" class="theme-toggle-btn">Modo Claro/Escuro</button>
-  <!-- conteúdo futuro -->
-      </div>
+      <div class="modal-content"></div>
     </div>
   </div>
 

--- a/main.js
+++ b/main.js
@@ -355,6 +355,10 @@ function renderSettingsModal(){
   const email = u && u.email ? u.email : '';
   const photo = u && u.photoURL ? u.photoURL : '';
   box.innerHTML = `
+    <header class="settings-modal-header">
+      <h2 id="settingsSheetTitle">Ajustes</h2>
+    </header>
+
     <div class="settings-card">
       <div class="settings-profile">
         <div class="settings-avatar">
@@ -414,6 +418,7 @@ function renderSettingsModal(){
         </button>
       </div>
     </div>`;
+  settingsModalEl.setAttribute('aria-labelledby', 'settingsSheetTitle');
   const img = box.querySelector('#settingsAvatar');
   if (img) {
     if (photo) {

--- a/style.css
+++ b/style.css
@@ -2108,7 +2108,47 @@ html[data-theme="light"] .invoice .invoice-group-date{ color: #111; }
 }
 
 /* ===================== SETTINGS (Ajustes) ===================== */
-#settingsModal .modal-content{padding:0 0 0 0;}
+#settingsModal {
+  top: calc(80px + constant(safe-area-inset-top));
+  top: calc(80px + env(safe-area-inset-top));
+  padding-top: 12px;
+  align-items: flex-end;
+}
+
+#settingsModal .bottom-modal-box {
+  max-height: calc(100vh - (80px + constant(safe-area-inset-top)) - var(--modal-bottom-gap, 0px) - 24px);
+  max-height: calc(100vh - (80px + env(safe-area-inset-top)) - var(--modal-bottom-gap, 0px) - 24px);
+}
+
+#settingsModal .modal-content {
+  padding: 0 18px 24px;
+}
+
+#settingsModal .settings-modal-header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 -18px 12px;
+  padding: 18px 18px 14px;
+  background: rgba(20,22,28,0.92);
+  border-radius: 18px 18px 0 0;
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+  box-shadow: 0 12px 24px rgba(0,0,0,0.35);
+}
+
+#settingsModal .settings-modal-header h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  color: rgba(255,255,255,0.96);
+  text-shadow: 0 0 6px rgba(0,0,0,0.45);
+}
+
+#settingsModal .modal-drag {
+  margin-bottom: 6px;
+}
 /* Settings modal – alignment and avatar fallback */
 #settingsModal .settings-card{ padding:14px; }
 #settingsModal .settings-list{ margin-top:12px; }
@@ -2723,6 +2763,15 @@ html[data-theme="light"] #settingsModal .bottom-modal-box{
   backdrop-filter: blur(16px) saturate(140%);
   border: 1px solid rgba(0,0,0,0.12);
   box-shadow: 0 14px 36px rgba(0,0,0,0.18);
+}
+html[data-theme="light"] #settingsModal .settings-modal-header {
+  background: rgba(255,255,255,0.92);
+  border-bottom: 1px solid rgba(0,0,0,0.08);
+  box-shadow: 0 12px 24px rgba(15,23,42,0.12);
+}
+html[data-theme="light"] #settingsModal .settings-modal-header h2 {
+  color: #111;
+  text-shadow: none;
 }
 html[data-theme="light"] #settingsModal h2 { color:#111; text-shadow:none; }
 html[data-theme="light"] #settingsModal .modal-close-btn { color:#111; opacity:.7; }


### PR DESCRIPTION
## Summary
- impede que o modal de Ajustes cubra o app-header limitando seu posicionamento no topo
- adiciona cabeçalho interno e conteúdo rolável sob o título "Ajustes"
- aplica ajustes visuais para o cabeçalho fixo nos temas escuro e claro

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5de7632088331b77914ffa1884a1e