### PR TITLE
Refine settings modal layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
   <meta http-equiv="Expires" content="0">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Caveat&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=1.4.9(a94)">
-  <link rel="stylesheet" href="login.css?v=1.4.9(a94)">
+  <link rel="stylesheet" href="style.css?v=1.4.9(a95)">
+  <link rel="stylesheet" href="login.css?v=1.4.9(a95)">
 
   <link rel="icon" type="image/png" sizes="192x192" href="icons/icon-192x192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="icons/icon-180x180.png">
@@ -74,15 +74,14 @@
   </div>
 
   <!-- Modal Sobre -->
-  <div id="settingsModal" class="bottom-modal backdrop-blur hidden">
+  <div id="settingsModal" class="bottom-modal backdrop-blur hidden" aria-labelledby="settingsSheetTitle">
     <div class="bottom-modal-box">
       <div class="modal-drag"></div>
-      <h2>Sobre</h2>
       <button id="closeSettingsModal" class="modal-close-btn" aria-label="Fechar">✕</button>
-      <div class="modal-content">
-  <button id="toggleThemeBtn" class="theme-toggle-btn">Modo Claro/Escuro</button>
-  <!-- conteúdo futuro -->
-      </div>
+      <header class="settings-modal-header">
+        <h2 id="settingsSheetTitle">Ajustes</h2>
+      </header>
+      <div class="modal-content"></div>
     </div>
   </div>
 
@@ -346,9 +345,9 @@
   <script src="js/utils/data-utils-global.js"></script>
   <script src="js/utils/currency-profiles.js"></script>
   
-  <script type="module" src="auth.js?v=1.4.9(a94)"></script>
-  <script type="module" src="login.view.js?v=1.4.9(a94)"></script>
-  <script type="module" src="main.js?v=1.4.9(a94)"></script>
+  <script type="module" src="auth.js?v=1.4.9(a95)"></script>
+  <script type="module" src="login.view.js?v=1.4.9(a95)"></script>
+  <script type="module" src="main.js?v=1.4.9(a95)"></script>
   <!-- Styles moved to style.css -->
 
   <!-- Toast de erro -->

--- a/main.js
+++ b/main.js
@@ -390,7 +390,7 @@ function renderSettingsModal(){
       </button>
     </div>
 
-    <h2 class="settings-title" style="margin:18px 0 8px 0;font-size:1rem;font-weight:700;color:var(--txt-main);">Sobre</h2>
+    <h2 class="settings-title" style="margin:18px 0 8px 0;font-size:1rem;font-weight:700;color:var(--txt-main);">Ajustes</h2>
     <div class="settings-list">
       <div class="settings-item">
         <div class="left">
@@ -414,6 +414,7 @@ function renderSettingsModal(){
         </button>
       </div>
     </div>`;
+  settingsModalEl.setAttribute('aria-labelledby', 'settingsSheetTitle');
   const img = box.querySelector('#settingsAvatar');
   if (img) {
     if (photo) {
@@ -1055,7 +1056,7 @@ function resolvePathForUser(user){
   return personalPath;
 }
 
-const APP_VERSION = 'v1.4.9(a94)';
+const APP_VERSION = 'v1.4.9(a95)';
 const METRICS_ENABLED = true;
 const _bootT0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
 function logMetric(name, payload) {

--- a/style.css
+++ b/style.css
@@ -2108,7 +2108,40 @@ html[data-theme="light"] .invoice .invoice-group-date{ color: #111; }
 }
 
 /* ===================== SETTINGS (Ajustes) ===================== */
-#settingsModal .modal-content{padding:0 0 0 0;}
+#settingsModal {
+  top: calc(80px + constant(safe-area-inset-top));
+  top: calc(80px + env(safe-area-inset-top));
+  padding-top: 12px;
+  align-items: flex-end;
+}
+
+#settingsModal .bottom-modal-box {
+  max-height: calc(100vh - (80px + constant(safe-area-inset-top)) - var(--modal-bottom-gap, 0px) - 24px);
+  max-height: calc(100vh - (80px + env(safe-area-inset-top)) - var(--modal-bottom-gap, 0px) - 24px);
+}
+
+#settingsModal .modal-content {
+  padding: 0 18px 24px;
+}
+
+#settingsModal .settings-modal-header {
+  flex: 0 0 auto;
+  margin: 0 18px 12px;
+  padding: 8px 0 4px;
+  text-align: center;
+}
+
+#settingsModal .settings-modal-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--txt-main);
+  text-shadow: none;
+}
+
+#settingsModal .modal-drag {
+  margin-bottom: 6px;
+}
 /* Settings modal – alignment and avatar fallback */
 #settingsModal .settings-card{ padding:14px; }
 #settingsModal .settings-list{ margin-top:12px; }
@@ -2723,6 +2756,14 @@ html[data-theme="light"] #settingsModal .bottom-modal-box{
   backdrop-filter: blur(16px) saturate(140%);
   border: 1px solid rgba(0,0,0,0.12);
   box-shadow: 0 14px 36px rgba(0,0,0,0.18);
+}
+html[data-theme="light"] #settingsModal .settings-modal-header {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+html[data-theme="light"] #settingsModal .settings-modal-header h2 {
+  color: #111;
 }
 html[data-theme="light"] #settingsModal h2 { color:#111; text-shadow:none; }
 html[data-theme="light"] #settingsModal .modal-close-btn { color:#111; opacity:.7; }

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Cache principal. Mantemos um único bucket e confiamos em URLs versionadas
 // e estratégias de atualização para evitar precisar "bump" manual a cada release.
-const CACHE = 'app-cache-1.4.9-a94';
+const CACHE = 'app-cache-1.4.9-a95';
 const RUNTIME = { pages: 'pages-v1', assets: 'assets-v1', cdn: 'cdn-v1' };
 const ASSETS = [
   './',


### PR DESCRIPTION
## Summary
- impede que o modal de Ajustes cubra o app-header e fixa o título fora do fluxo rolável
- ajusta o visual do cabeçalho e mantém o alinhamento dos itens, renomeando a seção inferior para “Ajustes”
- atualiza a versão dos assets para v1.4.9(a95)

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5de7632088331b77914ffa1884a1e