### PR TITLE
Prevent keyboard shift on transaction modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
   <meta http-equiv="Expires" content="0">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Caveat&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=1.4.9(a97)">
-  <link rel="stylesheet" href="login.css?v=1.4.9(a97)">
+  <link rel="stylesheet" href="style.css?v=1.4.9(a98)">
+  <link rel="stylesheet" href="login.css?v=1.4.9(a98)">
 
 
   <link rel="icon" type="image/png" sizes="192x192" href="icons/icon-192x192.png">
@@ -346,9 +346,9 @@
   <script src="js/utils/data-utils-global.js"></script>
   <script src="js/utils/currency-profiles.js"></script>
   
-  <script type="module" src="auth.js?v=1.4.9(a97)"></script>
-  <script type="module" src="login.view.js?v=1.4.9(a97)"></script>
-  <script type="module" src="main.js?v=1.4.9(a97)"></script>
+  <script type="module" src="auth.js?v=1.4.9(a98)"></script>
+  <script type="module" src="login.view.js?v=1.4.9(a98)"></script>
+  <script type="module" src="main.js?v=1.4.9(a98)"></script>
 
   <!-- Styles moved to style.css -->
 

--- a/main.js
+++ b/main.js
@@ -1056,7 +1056,7 @@ function resolvePathForUser(user){
   return personalPath;
 }
 
-const APP_VERSION = 'v1.4.9(a97)';
+const APP_VERSION = 'v1.4.9(a98)';
 
 const METRICS_ENABLED = true;
 const _bootT0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
@@ -1799,6 +1799,13 @@ function updateModalOpenState() {
 
   // Add/remove the existing modal-open class (used by CSS)
   if (open) root.classList.add('modal-open'); else root.classList.remove('modal-open');
+
+  if (root) {
+    const txModalEl = document.getElementById('txModal');
+    const txOpen = !!(txModalEl && !txModalEl.classList.contains('hidden'));
+    if (txOpen) root.classList.add('kb-lock-shift');
+    else root.classList.remove('kb-lock-shift');
+  }
 
   if (wrapperEl) {
     try {

--- a/style.css
+++ b/style.css
@@ -670,6 +670,11 @@ html.keyboard-open {
   will-change: transform;
 }
 
+html.keyboard-open.kb-lock-shift {
+  transform: none !important;
+  will-change: auto;
+}
+
 h1,h2,h3,h4,
 .executed-header,
 .planned-header,

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Cache principal. Mantemos um único bucket e confiamos em URLs versionadas
 // e estratégias de atualização para evitar precisar "bump" manual a cada release.
-const CACHE = 'app-cache-1.4.9-a97';
+const CACHE = 'app-cache-1.4.9-a98';
 
 const RUNTIME = { pages: 'pages-v1', assets: 'assets-v1', cdn: 'cdn-v1' };
 const ASSETS = [


### PR DESCRIPTION
## Summary
- lock the html transform when the transaction modal is open so the on-screen keyboard no longer shifts the entire app
- add a CSS override to keep the layout anchored while still respecting keyboard gap padding
- bump the asset query strings and cache version to 1.4.9(a98)

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d60713653c8331ae096c8503b5ab4a